### PR TITLE
Fixing a bug where array key was used but not set

### DIFF
--- a/plugin/includes/options_page.php
+++ b/plugin/includes/options_page.php
@@ -14,25 +14,25 @@ function imgix_options_page() {
 
 				<tr>
 					<td><label class="description" for="imgix_settings[cdn_link]"><?php _e('imgix Host', 'imgix_domain'); ?></td>
-					  <td><input id="imgix_settings[cdn_link]" type="text" name="imgix_settings[cdn_link]" value="<?php echo $imgix_options['cdn_link']; ?>" style="width:270px" /><small></td>
+					  <td><input id="imgix_settings[cdn_link]" type="text" name="imgix_settings[cdn_link]" value="<?php echo isset($imgix_options['cdn_link']) ? $imgix_options['cdn_link'] : ''; ?>" style="width:270px" /><small></td>
 					  <td>Example: http://yourcompany.imgix.net/</td>
 				</tr>
 
 				<tr>
 					<td><label class="description" for="imgix_settings[auto_format]"><?php _e('<a href="http://blog.imgix.com/post/90838796454/webp-jpeg-xr-progressive-jpg-support-w-auto" target="_blank">Auto Format</a> Images', 'auto_format'); ?></label></td>
-					<td><input id="imgix_settings[auto_format]" type="checkbox" name="imgix_settings[auto_format]" value="1" <?php echo $imgix_options['auto_format'] === "1" ? 'checked="checked"': ''; ?> /></td>
+					<td><input id="imgix_settings[auto_format]" type="checkbox" name="imgix_settings[auto_format]" value="1" <?php echo isset($imgix_options['auto_format']) && $imgix_options['auto_format'] === "1" ? 'checked="checked"': ''; ?> /></td>
 					<td></td>
 				</tr>
 
 				<tr>
 					<td><label class="description" for="imgix_settings[auto_enhance]"><?php _e('<a href="http://blog.imgix.com/post/85095931364/autoenhance" target="_blank">Auto Enhance</a> Images', 'auto_enhance'); ?></label></td>
-					<td><input id="imgix_settings[auto_enhance]" type="checkbox" name="imgix_settings[auto_enhance]" value="1" <?php echo $imgix_options['auto_enhance'] === "1" ? 'checked="checked"': ''; ?> /></td>
+					<td><input id="imgix_settings[auto_enhance]" type="checkbox" name="imgix_settings[auto_enhance]" value="1" <?php echo isset($imgix_options['auto_enhance']) && $imgix_options['auto_enhance'] === "1" ? 'checked="checked"': ''; ?> /></td>
 					<td></td>
 				</tr>
 
 				<tr>
 					<td><label class="description" for="imgix_settings[add_dpi2_srcset]"><?php _e('Automatically add retina images using srcset', 'add_dpi2_srcset'); ?></label></td>
-					<td><input id="imgix_settings[add_dpi2_srcset]" type="checkbox" name="imgix_settings[add_dpi2_srcset]" value="1" <?php echo $imgix_options['add_dpi2_srcset'] === "1" ? 'checked="checked"': ''; ?> /></td>
+					<td><input id="imgix_settings[add_dpi2_srcset]" type="checkbox" name="imgix_settings[add_dpi2_srcset]" value="1" <?php echo isset($imgix_options['add_dpi2_srcset']) && $imgix_options['add_dpi2_srcset'] === "1" ? 'checked="checked"': ''; ?> /></td>
 					<td></td>
 				</tr>
 


### PR DESCRIPTION
Checking that array keys are set before using them.  Otherwise PHP throws a notice.
