### PR TITLE
Version 1.1.0

### DIFF
--- a/imgix.php
+++ b/imgix.php
@@ -4,7 +4,7 @@ Plugin Name: imgix
 Description: A WordPress plugin to automatically use your existing (and future) WordPress images via <a href="http://www.imgix.com" target="_blank">imgix</a> for smaller, faster, and better looking images. <a href="https://github.com/wladston/imgix-wordpress" target="_blank">Learn more</a>.
 Author: imgix
 Author URI: http://www.imgix.com
-Version: 1.0.3
+Version: 1.1.0
 */
 
 // Variables

--- a/imgix.php
+++ b/imgix.php
@@ -1,7 +1,7 @@
 <?php
 /*
-Plugin Name: imgix plugin
-Description: A WordPress plugin to automatically use your existing (and future) WordPress images via <a href="http://www.imgix.com" target="_blank">imgix</a> for smaller, faster, and better looking images. <a href="https://github.com/imgix/imgix-wordpress" target="_blank">Learn more</a>.
+Plugin Name: imgix
+Description: A WordPress plugin to automatically use your existing (and future) WordPress images via <a href="http://www.imgix.com" target="_blank">imgix</a> for smaller, faster, and better looking images. <a href="https://github.com/wladston/imgix-wordpress" target="_blank">Learn more</a>.
 Author: imgix
 Author URI: http://www.imgix.com
 Version: 1.0.3

--- a/includes/do-functions.php
+++ b/includes/do-functions.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Find all img tags with sources matching "imgix.net" without the parameter
  * "srcset" and add the "srcset" parameter to all those images, appending a new
@@ -58,9 +57,9 @@ function get_global_params_string() {
 	$params = array();
 	// For now, only "auto" is supported.
 	$auto = array();
-        if (isset($imgix_options['auto_format']) && $imgix_options['auto_format'])
+	if (isset($imgix_options['auto_format']) && $imgix_options['auto_format'])
 		array_push($auto, "format");
-        if (isset($imgix_options['auto_enhance']) && $imgix_options['auto_enhance'])
+	if (isset($imgix_options['auto_enhance']) && $imgix_options['auto_enhance'])
 		array_push($auto, "enhance");
 	if (!empty($auto))
 		array_push($params, 'auto='.implode('%2C', $auto));
@@ -82,9 +81,9 @@ function ensure_valid_url($url) {
 	if(!$slash && strpos($pref, 'http') !== 0)
 		$pref = 'http://';
 
-        $result = $urlp['host'] ? $pref . $urlp['host'] : false;
+	$result = $urlp['host'] ? $pref . $urlp['host'] : false;
 	if($result)
-                return trailingslashit($result);
+		return trailingslashit($result);
 	return NULL;
 }
 
@@ -172,7 +171,7 @@ function imgix_extract_img_details($content) {
 function replace_host($str, $require_prefix = false) {
 	global $imgix_options;
 
-        if(!isset($imgix_options['cdn_link']) || !$imgix_options['cdn_link'])
+	if(!isset($imgix_options['cdn_link']) || !$imgix_options['cdn_link'])
 		return array($str, false);
 
 	$new_host = ensure_valid_url($imgix_options['cdn_link']);
@@ -242,6 +241,17 @@ function imgix_replace_non_wp_images($content){
 	return $content;
 }
 
+add_action('wp_head', 'imgix_wp_head', 1 );
+function imgix_wp_head() {
+	global $imgix_options;
+
+	if (isset($imgix_options['cdn_link']) && $imgix_options['cdn_link']) {
+		printf("<link rel='dns-prefetch' href='%s'/>",
+			preg_replace('/^https?:/','', untrailingslashit($imgix_options['cdn_link']) )
+		);
+	}
+}
+
 if (isset($imgix_options['add_dpi2_srcset']) && $imgix_options['add_dpi2_srcset']) {
 	function buffer_start() { ob_start("add_retina"); }
 	function buffer_end() { ob_end_flush(); }
@@ -249,4 +259,3 @@ if (isset($imgix_options['add_dpi2_srcset']) && $imgix_options['add_dpi2_srcset'
 	add_action('shutdown', 'buffer_end');
 	add_filter('the_content', 'add_retina');
 }
-?>

--- a/includes/do-functions.php
+++ b/includes/do-functions.php
@@ -1,8 +1,8 @@
 <?php
 
 /**
- * Find all img tags with sources matching "imgix.net" without the parameter 
- * "srcset" and add the "srcset" parameter to all those images, appending a new 
+ * Find all img tags with sources matching "imgix.net" without the parameter
+ * "srcset" and add the "srcset" parameter to all those images, appending a new
  * source using the "dpr=2" modifier.
  *
  * @return string Content with retina-enriched image tags.
@@ -170,6 +170,10 @@ function imgix_extract_img_details($content) {
  */
 function replace_host($str, $require_prefix = false) {
 	global $imgix_options;
+
+	if(!isset($imgix_options['cdn_link']))
+		return array($str, false);
+
 	$new_host = ensure_valid_url($imgix_options['cdn_link']);
 	if(!$new_host)
 		return array($str, false);
@@ -183,7 +187,7 @@ function replace_host($str, $require_prefix = false) {
 }
 
 /**
- * Given an inmage URL and the target wordpress size to display the image, 
+ * Given an inmage URL and the target wordpress size to display the image,
  * return the appropriate transformed image source.
  *
  * @return string equivalent imgix source with correct parameters.

--- a/includes/do-functions.php
+++ b/includes/do-functions.php
@@ -58,9 +58,9 @@ function get_global_params_string() {
 	$params = array();
 	// For now, only "auto" is supported.
 	$auto = array();
-	if ($imgix_options['auto_format'])
+        if (isset($imgix_options['auto_format']) && $imgix_options['auto_format'])
 		array_push($auto, "format");
-	if ($imgix_options['auto_enhance'])
+        if (isset($imgix_options['auto_enhance']) && $imgix_options['auto_enhance'])
 		array_push($auto, "enhance");
 	if (!empty($auto))
 		array_push($params, 'auto='.implode('%2C', $auto));
@@ -241,7 +241,7 @@ function imgix_replace_non_wp_images($content){
 	return $content;
 }
 
-if($imgix_options['add_dpi2_srcset']) {
+if (isset($imgix_options['add_dpi2_srcset']) && $imgix_options['add_dpi2_srcset']) {
 	function buffer_start() { ob_start("add_retina"); }
 	function buffer_end() { ob_end_flush(); }
 	add_action('after_setup_theme', 'buffer_start');

--- a/includes/do-functions.php
+++ b/includes/do-functions.php
@@ -81,9 +81,10 @@ function ensure_valid_url($url) {
 	$pref = array_key_exists('scheme', $urlp) ? $urlp['scheme'].'://' : $slash;
 	if(!$slash && strpos($pref, 'http') !== 0)
 		$pref = 'http://';
-	$result = $urlp['host'] ? $pref . $urlp['host'] . $urlp['path'] : '';
+
+        $result = $urlp['host'] ? $pref . $urlp['host'] : false;
 	if($result)
-		return substr($result, -1) == "/" ? $result: $result.'/';
+                return trailingslashit($result);
 	return NULL;
 }
 
@@ -171,7 +172,7 @@ function imgix_extract_img_details($content) {
 function replace_host($str, $require_prefix = false) {
 	global $imgix_options;
 
-	if(!isset($imgix_options['cdn_link']))
+        if(!isset($imgix_options['cdn_link']) || !$imgix_options['cdn_link'])
 		return array($str, false);
 
 	$new_host = ensure_valid_url($imgix_options['cdn_link']);

--- a/includes/options_page.php
+++ b/includes/options_page.php
@@ -6,16 +6,16 @@ function imgix_options_page() {
 ?>
 	<div class="wrap">
 		<p><img src="https://assets.imgix.net/imgix-logo-web-2014.pdf?page=2&fm=png&w=200&h=200"></p>
-		<p><strong>Need help getting started?</strong> It's easy! Check out our <a href="https://github.com/imgix/imgix-wordpress#getting-started" target="_blank">instructions and screencast.</a></p>
+		<p><strong>Need help getting started?</strong> It's easy! Check out our <a href="https://github.com/wladston/imgix-wordpress#getting-started" target="_blank">instructions.</a></p>
 		<form method="post" action="options.php">
 			<?php settings_fields('imgix_settings_group'); ?>
 
 			<table>
 
 				<tr>
-					<td><label class="description" for="imgix_settings[cdn_link]"><?php _e('imgix Host', 'imgix_domain'); ?></td>
-					  <td><input id="imgix_settings[cdn_link]" type="text" name="imgix_settings[cdn_link]" value="<?php echo isset($imgix_options['cdn_link']) ? $imgix_options['cdn_link'] : ''; ?>" style="width:270px" /><small></td>
-					  <td>Example: http://yourcompany.imgix.net/</td>
+					<td><label class="description" for="imgix_settings[cdn_link]"><?php _e('imgix Source', 'imgix_domain'); ?></td>
+					  <td><input id="imgix_settings[cdn_link]" type="url" name="imgix_settings[cdn_link]" placeholder="http://yourcompany.imgix.net" value="<?php echo isset($imgix_options['cdn_link']) ? $imgix_options['cdn_link'] : ''; ?>" style="width:270px" /><small></td>
+					  <td></td>
 				</tr>
 
 				<tr>
@@ -47,7 +47,7 @@ function imgix_options_page() {
 		</form>
 
 		<p class="description">
-			This Plugin is powered and created by <a href="http://www.imgix.com" target="_blank">imgix</a>. You can find the code on <a href="https://github.com/imgix/imgix-wordpress" target="_blank">GitHub</a>.
+			This plugin is powered by <a href="http://www.imgix.com" target="_blank">imgix</a>. You can find and contribute to the code on <a href="https://github.com/wladston/imgix-wordpress" target="_blank">GitHub</a>.
 		</p>
 	</div>
 <?php
@@ -55,7 +55,7 @@ function imgix_options_page() {
 }
 
 function imgix_add_options_link() {
-	add_options_page('imgix plugin', 'imgix plugin', 'manage_options', 'imgix-options', 'imgix_options_page');
+	add_options_page('imgix', 'imgix', 'manage_options', 'imgix-options', 'imgix_options_page');
 }
 add_action('admin_menu', 'imgix_add_options_link');
 
@@ -65,5 +65,3 @@ function imgix_register_settings() {
 }
 
 add_action('admin_init', 'imgix_register_settings');
-
-?>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imgix-wordpress",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "official imgix WordPress plugin",
   "main": "",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -18,7 +18,7 @@ Easily use imgix style
 
 == Installation ==
 
-See https://github.com/imgix/imgix-wordpress
+See https://github.com/wladston/imgix-wordpress
 
 == Frequently Asked Questions ==
 


### PR DESCRIPTION
- Adds dns-prefix link tag to wp_head
- Normalizes imgix url if trailing slash was omitted
- Adds sanity checks for saved options
- Removes broken imgix/imgix-wordpress references
- Only attempts replace if imgix URL has been set and is not ''
