### PR TITLE
Version 1.2.0

### DIFF
--- a/imgix.php
+++ b/imgix.php
@@ -1,30 +1,39 @@
 <?php
-/*
-Plugin Name: imgix
-Description: A WordPress plugin to automatically use your existing (and future) WordPress images via <a href="http://www.imgix.com" target="_blank">imgix</a> for smaller, faster, and better looking images. <a href="https://github.com/wladston/imgix-wordpress" target="_blank">Learn more</a>.
-Author: imgix
-Author URI: http://www.imgix.com
-Version: 1.1.0
-*/
+/**
+ * imgix
+ *
+ * @package imgix
+ * @author wladston
+ * @license BSD-2
+ *
+ * @wordpress-plugin
+ * Plugin Name: imgix
+ * PLugin URI:  https://github.com/wladston/imgix-wordpress
+ * Description: A WordPress plugin to automatically use your existing (and future) WordPress images via <a href="http://www.imgix.com" target="_blank">imgix</a> for smaller, faster, and better looking images. <a href="https://github.com/wladston/imgix-wordpress" target="_blank">Learn more</a>.
+ * Version:     1.1.0
+ * Author:      wladston
+ * Author URI:  http://github.com/wladston
+ */
 
 // Variables
-$imgix_options = get_option('imgix_settings');
+$imgix_options = get_option( 'imgix_settings' );
 
-include('includes/do-functions.php');
-include('includes/options_page.php');
+include( 'includes/do-functions.php' );
+include( 'includes/options_page.php' );
 
 // Settings
-function imgix_plugin_admin_action_links($links, $file) {
+function imgix_plugin_admin_action_links( $links, $file ) {
 	static $my_plugin;
-	if (!$my_plugin) {
-		$my_plugin = plugin_basename(__FILE__);
+
+	if ( ! $my_plugin ) {
+		$my_plugin = plugin_basename( __FILE__ );
 	}
-	if ($file == $my_plugin) {
+
+	if ( $file === $my_plugin ) {
 		$settings_link = '<a href="options-general.php?page=imgix-options">Settings</a>';
-		array_unshift($links, $settings_link);
+		array_unshift( $links, $settings_link );
 	}
 	return $links;
 }
 
-add_filter('plugin_action_links', 'imgix_plugin_admin_action_links', 10, 2);
-?>
+add_filter( 'plugin_action_links', 'imgix_plugin_admin_action_links', 10, 2 );

--- a/imgix.php
+++ b/imgix.php
@@ -10,7 +10,7 @@
  * Plugin Name: imgix
  * PLugin URI:  https://github.com/wladston/imgix-wordpress
  * Description: A WordPress plugin to automatically use your existing (and future) WordPress images via <a href="http://www.imgix.com" target="_blank">imgix</a> for smaller, faster, and better looking images. <a href="https://github.com/wladston/imgix-wordpress" target="_blank">Learn more</a>.
- * Version:     1.1.0
+ * Version:     1.2.0
  * Author:      wladston
  * Author URI:  http://github.com/wladston
  */

--- a/includes/do-functions.php
+++ b/includes/do-functions.php
@@ -23,9 +23,11 @@ function add_retina($content) {
 function imgix_extract_imgs($content) {
 	preg_match_all('/src=["\']http.+\/([^\s]+?)["\']/', $content, $matches);
 	$results = array();
-	if ($matches)
-		foreach ($matches[1] as $url)
+	if ($matches) {
+		foreach ($matches[1] as $url){
 			array_push($results, $url);
+		}
+	}
 	return $results;
 }
 
@@ -57,12 +59,18 @@ function get_global_params_string() {
 	$params = array();
 	// For now, only "auto" is supported.
 	$auto = array();
-	if (isset($imgix_options['auto_format']) && $imgix_options['auto_format'])
+	if (isset($imgix_options['auto_format']) && $imgix_options['auto_format']) {
 		array_push($auto, "format");
-	if (isset($imgix_options['auto_enhance']) && $imgix_options['auto_enhance'])
+	}
+
+	if (isset($imgix_options['auto_enhance']) && $imgix_options['auto_enhance']) {
 		array_push($auto, "enhance");
-	if (!empty($auto))
+	}
+
+	if (!empty($auto)) {
 		array_push($params, 'auto='.implode('%2C', $auto));
+	}
+
 	return implode('&amp;', $params);
 }
 
@@ -74,16 +82,24 @@ function get_global_params_string() {
  */
 function ensure_valid_url($url) {
 	$slash = strpos($url, '//') == 0 ? '//' : '';
-	if($slash)
+
+	if($slash) {
 		$url = substr($url, 2);
+	}
+
 	$urlp = parse_url($url);
 	$pref = array_key_exists('scheme', $urlp) ? $urlp['scheme'].'://' : $slash;
-	if(!$slash && strpos($pref, 'http') !== 0)
+
+	if(!$slash && strpos($pref, 'http') !== 0) {
 		$pref = 'http://';
+	}
 
 	$result = $urlp['host'] ? $pref . $urlp['host'] : false;
-	if($result)
+
+	if($result) {
 		return trailingslashit($result);
+	}
+
 	return NULL;
 }
 
@@ -94,22 +110,26 @@ function ensure_valid_url($url) {
  */
 function get_size_info($size){
 	global $_wp_additional_image_sizes;
-	if($size == 'original')
+	if($size == 'original'){
 		return array('width' => '', 'height' => '', 'crop' => false);
-	elseif(is_array($size))
+	}
+	elseif(is_array($size)){
 		return array('width' => $size[1],
 		             'height' => $size[0],
 		             'crop' => false);
-	elseif (in_array($size, array('thumbnail', 'medium', 'large')))
+	}
+	elseif (in_array($size, array('thumbnail', 'medium', 'large'))){
 		return array('width' => get_option($size . '_size_w'),
 					 'height' => get_option($size . '_size_h'),
 					 'crop' => (bool) get_option( $size . '_crop'));
-	elseif(isset($_wp_additional_image_sizes[$size]))
+	}
+	elseif(isset($_wp_additional_image_sizes[$size])){
 		return array('width' => $_wp_additional_image_sizes[$size]['width'],
 					 'height' => $_wp_additional_image_sizes[$size]['height'],
 					 'crop' => $_wp_additional_image_sizes[$size]['crop']);
-	else
-		return NULL;
+	}
+
+	return NULL;
 }
 
 /**
@@ -171,12 +191,14 @@ function imgix_extract_img_details($content) {
 function replace_host($str, $require_prefix = false) {
 	global $imgix_options;
 
-	if(!isset($imgix_options['cdn_link']) || !$imgix_options['cdn_link'])
+	if(!isset($imgix_options['cdn_link']) || !$imgix_options['cdn_link']){
 		return array($str, false);
+	}
 
 	$new_host = ensure_valid_url($imgix_options['cdn_link']);
-	if(!$new_host)
+	if(!$new_host){
 		return array($str, false);
+	}
 	// As soon as srcset is supported…
 	//$prefix = $require_prefix? 'srcs?e?t?=[\'"]|,[\S+\n\r\s]*': '';
 	$prefix = $require_prefix? 'src=[\'"]': '';
@@ -199,12 +221,15 @@ function replace_src($src, $size) {
 		if ($match_src) {
 			$g_params = get_global_params_string();
 			$params = array();
-			if (isset($size_info['crop']) && $size_info['crop'])
+			if (isset($size_info['crop']) && $size_info['crop']) {
 				array_push($params, 'fit=crop');
-			if (isset($size_info['width']) && $size_info['width'])
+			}
+			if (isset($size_info['width']) && $size_info['width']) {
 				array_push($params, 'w='.$size_info['width']);
-			if (isset($size_info['height']) && $size_info['height'])
+			}
+			if (isset($size_info['height']) && $size_info['height']) {
 				array_push($params, 'h='.$size_info['height']);
+			}
 			$p = implode('&amp;', $params);
 			$p = ($p && $g_params) ? $p .'&amp;'. $g_params : $p . $g_params;
 			$src = apply_parameters_to_url($src, $p, $src);
@@ -235,8 +260,9 @@ function imgix_replace_non_wp_images($content){
 
 		// Apply global parameters.
 		$g_params = get_global_params_string();
-		foreach (imgix_extract_imgs($content) as $img_url)
+		foreach (imgix_extract_imgs($content) as $img_url)	{
 			$content = apply_parameters_to_url($img_url, $g_params, $content);
+		}
 	}
 	return $content;
 }

--- a/includes/do-functions.php
+++ b/includes/do-functions.php
@@ -1,5 +1,10 @@
 <?php
 /**
+ *
+ * @package imgix
+ */
+
+/**
  * Find all img tags with sources matching "imgix.net" without the parameter
  * "srcset" and add the "srcset" parameter to all those images, appending a new
  * source using the "dpr=2" modifier.
@@ -7,12 +12,13 @@
  * @return string Content with retina-enriched image tags.
  */
 
-function add_retina($content) {
-	$pattern = '/<img((?![^>]+srcset)([^>]*)';
+function add_retina( $content ) {
+	$pattern = '/<img((?![^>]+srcset )([^>]*)';
 	$pattern .= 'src=[\'"]([^\'"]*imgix.net[^\'"]*\?[^\'"]*w=[^\'"]*)[\'"]([^>]*)*?)>/i';
 	$repl = '<img$2src="$3" srcset="${3}, ${3}&amp;dpr=2 2x, ${3}&amp;dpr=3 3x,"$4>';
-	$content = preg_replace($pattern, $repl, $content);
-	return preg_replace($pattern, $repl, $content);
+	$content = preg_replace( $pattern, $repl, $content );
+
+	return preg_replace( $pattern, $repl, $content );
 }
 
 /**
@@ -20,14 +26,16 @@ function add_retina($content) {
  *
  * @return array An array of matching arrays with two keys: 'url' and 'params'
  */
-function imgix_extract_imgs($content) {
-	preg_match_all('/src=["\']http.+\/([^\s]+?)["\']/', $content, $matches);
+function imgix_extract_imgs( $content ) {
+	preg_match_all( '/src=["\']http.+\/([^\s]+?)["\']/', $content, $matches );
 	$results = array();
-	if ($matches) {
-		foreach ($matches[1] as $url){
-			array_push($results, $url);
+
+	if ( $matches ) {
+		foreach ( $matches[1] as $url ) {
+			array_push( $results, $url );
 		}
 	}
+
 	return $results;
 }
 
@@ -38,14 +46,17 @@ function imgix_extract_imgs($content) {
  *
  * @return string Content with matching URLs having the new querystrings.
  */
-function apply_parameters_to_url($url, $params, $content) {
-	$parts = explode('?', $url.'?');
-	list($base_url, $base_params) = array($parts[0], $parts[1]);
+function apply_parameters_to_url( $url, $params, $content ) {
+	$parts = explode( '?', $url . '?' );
+
+	list( $base_url, $base_params ) = array( $parts[0], $parts[1] );
+
 	$new_url = $old_url = $base_url;
 	$new_url .= '?' . $params;
 	$new_url .= $base_params ? '&amp;' . $base_params : '';
 	$old_url .= $base_params ? '?'. $base_params : '';
-	return str_replace($old_url, $new_url, $content);
+
+	return str_replace( $old_url, $new_url, $content );
 }
 
 /**
@@ -59,45 +70,46 @@ function get_global_params_string() {
 	$params = array();
 	// For now, only "auto" is supported.
 	$auto = array();
-	if (isset($imgix_options['auto_format']) && $imgix_options['auto_format']) {
-		array_push($auto, "format");
+
+	if ( isset( $imgix_options['auto_format'] ) && $imgix_options['auto_format'] ) {
+		array_push( $auto, 'format' );
 	}
 
-	if (isset($imgix_options['auto_enhance']) && $imgix_options['auto_enhance']) {
-		array_push($auto, "enhance");
+	if ( isset( $imgix_options['auto_enhance'] ) && $imgix_options['auto_enhance'] ) {
+		array_push( $auto, 'enhance' );
 	}
 
-	if (!empty($auto)) {
-		array_push($params, 'auto='.implode('%2C', $auto));
+	if ( ! empty( $auto ) ) {
+		array_push( $params, 'auto=' . implode( '%2C', $auto ) );
 	}
 
-	return implode('&amp;', $params);
+	return implode( '&amp;', $params );
 }
 
 /**
- * Sanitize a given URL to make sure it has a scheme (or alternatively, '//'),
+ * Sanitize a given URL to make sure it has a scheme (or alternatively, '//' ),
  * host, path, and ends with a '/'.
  *
  * @return string A sanitized URL.
  */
-function ensure_valid_url($url) {
-	$slash = strpos($url, '//') == 0 ? '//' : '';
+function ensure_valid_url( $url ) {
+	$slash = strpos( $url, '//' ) == 0 ? '//' : '';
 
-	if($slash) {
-		$url = substr($url, 2);
+	if ( $slash ) {
+		$url = substr( $url, 2 );
 	}
 
-	$urlp = parse_url($url);
-	$pref = array_key_exists('scheme', $urlp) ? $urlp['scheme'].'://' : $slash;
+	$urlp = parse_url( $url );
+	$pref = array_key_exists( 'scheme', $urlp ) ? $urlp['scheme'] . '://' : $slash;
 
-	if(!$slash && strpos($pref, 'http') !== 0) {
+	if ( ! $slash && strpos( $pref, 'http' ) !== 0 ) {
 		$pref = 'http://';
 	}
 
 	$result = $urlp['host'] ? $pref . $urlp['host'] : false;
 
-	if($result) {
-		return trailingslashit($result);
+	if ( $result ) {
+		return trailingslashit( $result );
 	}
 
 	return NULL;
@@ -108,25 +120,34 @@ function ensure_valid_url($url) {
  *
  * @return array Size's width, height and crop values.
  */
-function get_size_info($size){
+function get_size_info( $size ) {
 	global $_wp_additional_image_sizes;
-	if($size == 'original'){
-		return array('width' => '', 'height' => '', 'crop' => false);
+
+	if ( $size === 'original' ) {
+		return array(
+			'width' => '',
+			'height' => '',
+			'crop' => false,
+		);
+	} elseif ( is_array( $size ) ) {
+		return array(
+			'width' => $size[1],
+			'height' => $size[0],
+			'crop' => false,
+		);
+	} elseif ( in_array( $size, array( 'thumbnail', 'medium', 'large' ) ) ) {
+		return array(
+			'width' => get_option( $size . '_size_w' ),
+			'height' => get_option( $size . '_size_h' ),
+			'crop' => (boolean) get_option( $size . '_crop' ),
+		);
 	}
-	elseif(is_array($size)){
-		return array('width' => $size[1],
-		             'height' => $size[0],
-		             'crop' => false);
-	}
-	elseif (in_array($size, array('thumbnail', 'medium', 'large'))){
-		return array('width' => get_option($size . '_size_w'),
-					 'height' => get_option($size . '_size_h'),
-					 'crop' => (bool) get_option( $size . '_crop'));
-	}
-	elseif(isset($_wp_additional_image_sizes[$size])){
-		return array('width' => $_wp_additional_image_sizes[$size]['width'],
-					 'height' => $_wp_additional_image_sizes[$size]['height'],
-					 'crop' => $_wp_additional_image_sizes[$size]['crop']);
+	elseif ( isset( $_wp_additional_image_sizes[$size] ) ) {
+		return array(
+			'width' => $_wp_additional_image_sizes[$size]['width'],
+			'height' => $_wp_additional_image_sizes[$size]['height'],
+			'crop' => $_wp_additional_image_sizes[$size]['crop'],
+		);
 	}
 
 	return NULL;
@@ -150,30 +171,33 @@ function get_size_info($size){
  * @return array An array of arrays that has extracted the URL's inferred w',
  * 'h', and 'type'
  */
-function imgix_extract_img_details($content) {
-	preg_match_all('/-([0-9]+)x([0-9]+)\.([^"\']+)/', $content, $matches);
+function imgix_extract_img_details( $content ) {
+	preg_match_all( '/-([0-9]+)x([0-9]+)\.([^"\']+)/', $content, $matches );
 
-	$lookup = array('raw', 'w', 'h', 'type');
+	$lookup = array( 'raw', 'w', 'h', 'type' );
 	$data = array();
-	foreach ($matches as $k => $v) {
 
-		foreach ($v as $ind => $val) {
-			if (!array_key_exists($ind, $data)) {
-				$data[$ind] = array();
+	foreach ( $matches as $k => $v ) {
+
+		foreach ( $v as $index => $value ) {
+
+			if (!array_key_exists( $index, $data ) ) {
+				$data[$index] = array();
 			}
 
 			$key = $lookup[$k];
-			if ($key === 'type') {
-				if (strpos($val, '?') !== false) {
-					$parts = explode('?', $val);
-					$data[$ind]['type'] = $parts[0];
-					$data[$ind]['extra'] = $parts[1];
+
+			if ( $key === 'type' ) {
+				if ( strpos( $value, '?' ) !== false ) {
+					$parts = explode( '?', $value );
+					$data[$index]['type'] = $parts[0];
+					$data[$index]['extra'] = $parts[1];
 				} else {
-					$data[$ind]['type'] = $val;
-					$data[$ind]['extra'] = '';
+					$data[$index]['type'] = $value;
+					$data[$index]['extra'] = '';
 				}
 			} else {
-				$data[$ind][$key] = $val;
+				$data[$index][$key] = $value;
 			}
 		}
 	}
@@ -188,24 +212,26 @@ function imgix_extract_img_details($content) {
  * @return array An array countaining the final string, and a boolean value
  * indicating if it's different from the given input string.
  */
-function replace_host($str, $require_prefix = false) {
+function replace_host( $str, $require_prefix = false ) {
 	global $imgix_options;
 
-	if(!isset($imgix_options['cdn_link']) || !$imgix_options['cdn_link']){
-		return array($str, false);
+	if ( ! isset( $imgix_options['cdn_link'] ) || ! $imgix_options['cdn_link'] ) {
+		return array( $str, false );
 	}
 
-	$new_host = ensure_valid_url($imgix_options['cdn_link']);
-	if(!$new_host){
-		return array($str, false);
+	$new_host = ensure_valid_url( $imgix_options['cdn_link'] );
+	if ( ! $new_host ) {
+		return array( $str, false );
 	}
+
 	// As soon as srcset is supported…
 	//$prefix = $require_prefix? 'srcs?e?t?=[\'"]|,[\S+\n\r\s]*': '';
 	$prefix = $require_prefix? 'src=[\'"]': '';
-	$src = '('.preg_quote(home_url('/'), '/').'|\/\/)';
-	$patt = '/('.$prefix.')'.$src.'/i';
-	$str = preg_replace($patt, '$1'.$new_host, $str, -1, $count);
-	return array($str, (bool) $count);
+	$src = '(' . preg_quote( home_url( '/' ), '/' ) . '|\/\/)';
+	$patt = '/(' . $prefix . ' )' . $src . '/i';
+	$str = preg_replace( $patt, '$1' . $new_host, $str, -1, $count );
+
+	return array( $str, (boolean) $count );
 }
 
 /**
@@ -214,27 +240,35 @@ function replace_host($str, $require_prefix = false) {
  *
  * @return string equivalent imgix source with correct parameters.
  */
-function replace_src($src, $size) {
-	$size_info = get_size_info($size);
-	if($size_info){
-		list($src, $match_src) = replace_host($src, false);
-		if ($match_src) {
+function replace_src( $src, $size ) {
+	$size_info = get_size_info( $size );
+
+	if ( $size_info ) {
+
+		list( $src, $match_src ) = replace_host( $src, false );
+
+		if ( $match_src ) {
 			$g_params = get_global_params_string();
 			$params = array();
-			if (isset($size_info['crop']) && $size_info['crop']) {
-				array_push($params, 'fit=crop');
+
+			if ( isset( $size_info['crop'] ) && $size_info['crop'] ) {
+				array_push( $params, 'fit=crop' );
 			}
-			if (isset($size_info['width']) && $size_info['width']) {
-				array_push($params, 'w='.$size_info['width']);
+
+			if ( isset( $size_info['width'] ) && $size_info['width'] ) {
+				array_push( $params, 'w=' . $size_info['width'] );
 			}
-			if (isset($size_info['height']) && $size_info['height']) {
-				array_push($params, 'h='.$size_info['height']);
+
+			if ( isset( $size_info['height'] ) && $size_info['height'] ) {
+				array_push( $params, 'h=' . $size_info['height'] );
 			}
-			$p = implode('&amp;', $params);
-			$p = ($p && $g_params) ? $p .'&amp;'. $g_params : $p . $g_params;
-			$src = apply_parameters_to_url($src, $p, $src);
+
+			$p = implode( '&amp;', $params );
+			$p = ( $p && $g_params ) ? $p . '&amp;' . $g_params : $p . $g_params;
+			$src = apply_parameters_to_url( $src, $p, $src );
 		}
 	}
+
 	return $src;
 }
 
@@ -245,13 +279,18 @@ function imgix_file_url( $url ) {
 	$imgix_url = $imgix_options['cdn_link'];
 	$file = pathinfo( $url );
 
-	if ( in_array( $file['extension'], ['jpg','gif','png','jpeg'] ) ) {
-		return str_replace( get_bloginfo('wpurl'), $imgix_url, $url );
+	if ( ! $imgix_url ) {
+		return $url;
+	}
+
+	if ( in_array( $file['extension'], array( 'jpg','gif','png','jpeg' ) ) ) {
+		return str_replace( get_bloginfo( 'wpurl' ), $imgix_url, $url );
 	}
 
 	return $url;
 }
-add_filter('wp_get_attachment_url', 'imgix_file_url');
+add_filter( 'wp_get_attachment_url', 'imgix_file_url' );
+add_filter( 'imgix/add-image-url', 'imgix_file_url' );
 
 /**
  *
@@ -261,9 +300,9 @@ add_filter('wp_get_attachment_url', 'imgix_file_url');
  * @param array $image_meta
  * @param $attachment_id
  *
- * @return [type]          [description]
+ * @return array $sources
  */
-function imgix_cdn_srcset($sources, $size_array, $image_src, $image_meta, $attachment_id ){
+function imgix_cdn_srcset( $sources, $size_array, $image_src, $image_meta, $attachment_id ) {
 
 	global $imgix_options;
 
@@ -271,7 +310,7 @@ function imgix_cdn_srcset($sources, $size_array, $image_src, $image_meta, $attac
 
 	foreach ( $sources as $source ) {
 
-		$sources[ $source['value'] ]['url'] = str_replace( get_bloginfo('wpurl'), $imgix_url, $sources[ $source['value'] ]['url']);
+		$sources[$source['value']]['url'] = apply_filters( 'imgix/add-image-url', $sources[ $source['value'] ]['url'] );
 
 	}
 
@@ -279,44 +318,45 @@ function imgix_cdn_srcset($sources, $size_array, $image_src, $image_meta, $attac
 }
 add_filter( 'wp_calculate_image_srcset', 'imgix_cdn_srcset', 10, 5 );
 
-function imgix_replace_non_wp_images($content){
-	list($content, $match) = replace_host($content, true);
-	if($match) {
-		//Apply image-tag-encoded params for every image in $content.
-		foreach (imgix_extract_img_details($content) as $img) {
+function imgix_replace_non_wp_images( $content ) {
+	list( $content, $match ) = replace_host( $content, true );
+
+	if ( $match ) {
+		// Apply image-tag-encoded params for every image in $content.
+		foreach ( imgix_extract_img_details( $content ) as $img ) {
 			$to_replace = $img['raw'];
-			$extra_params = $img['extra'] ? '&amp;'.$img['extra'] : '';
-			$new_url = '.'.$img['type'].'?h='.$img['h'].'&amp;w='.$img['w'].$extra_params;
-			$content = str_replace($to_replace, $new_url, $content);
+			$extra_params = $img['extra'] ? '&amp;' . $img['extra'] : '';
+			$new_url = '.' . $img['type'] . '?h=' . $img['h'] . '&amp;w=' . $img['w'] . $extra_params;
+			$content = str_replace( $to_replace, $new_url, $content );
 		}
 
 		// Apply global parameters.
 		$g_params = get_global_params_string();
-		foreach (imgix_extract_imgs($content) as $img_url)	{
-			$content = apply_parameters_to_url($img_url, $g_params, $content);
+		foreach ( imgix_extract_imgs( $content ) as $img_url ) {
+			$content = apply_parameters_to_url( $img_url, $g_params, $content );
 		}
 	}
 	return $content;
 }
 
-add_filter('the_content', 'imgix_replace_non_wp_images');
+add_filter( 'the_content', 'imgix_replace_non_wp_images' );
 
 function imgix_wp_head() {
 	global $imgix_options;
 
-	if (isset($imgix_options['cdn_link']) && $imgix_options['cdn_link']) {
-		printf("<link rel='dns-prefetch' href='%s'/>",
-			preg_replace('/^https?:/','', untrailingslashit($imgix_options['cdn_link']) )
+	if ( isset( $imgix_options['cdn_link'] ) && $imgix_options['cdn_link'] ) {
+		printf( "<link rel='dns-prefetch' href='%s'/>",
+			preg_replace( '/^https?:/', '', untrailingslashit( $imgix_options['cdn_link'] ) )
 		);
 	}
 }
 
-add_action('wp_head', 'imgix_wp_head', 1 );
+add_action( 'wp_head', 'imgix_wp_head', 1 );
 
-if (isset($imgix_options['add_dpi2_srcset']) && $imgix_options['add_dpi2_srcset']) {
+if (isset( $imgix_options['add_dpi2_srcset'] ) && $imgix_options['add_dpi2_srcset'] ) {
 	function buffer_start() { ob_start("add_retina"); }
 	function buffer_end() { ob_end_flush(); }
-	add_action('after_setup_theme', 'buffer_start');
-	add_action('shutdown', 'buffer_end');
-	add_filter('the_content', 'add_retina');
+	add_action('after_setup_theme', 'buffer_start' );
+	add_action('shutdown', 'buffer_end' );
+	add_filter('the_content', 'add_retina' );
 }

--- a/includes/do-functions.php
+++ b/includes/do-functions.php
@@ -213,7 +213,6 @@ function replace_src($src, $size) {
 	return $src;
 }
 
-add_filter('image_downsize', 'no_image_downsize', 10, 3);
 function no_image_downsize($return, $id, $size) {
 	$url = wp_get_attachment_url($id);
 	$new_url = replace_src($url, $size);
@@ -221,7 +220,8 @@ function no_image_downsize($return, $id, $size) {
 	return array($new_url, $size_info['width'], $size_info['height'], true);
 }
 
-add_filter('the_content', 'imgix_replace_non_wp_images');
+add_filter('image_downsize', 'no_image_downsize', 10, 3);
+
 function imgix_replace_non_wp_images($content){
 	list($content, $match) = replace_host($content, true);
 	if($match) {
@@ -241,7 +241,8 @@ function imgix_replace_non_wp_images($content){
 	return $content;
 }
 
-add_action('wp_head', 'imgix_wp_head', 1 );
+add_filter('the_content', 'imgix_replace_non_wp_images');
+
 function imgix_wp_head() {
 	global $imgix_options;
 
@@ -251,6 +252,8 @@ function imgix_wp_head() {
 		);
 	}
 }
+
+add_action('wp_head', 'imgix_wp_head', 1 );
 
 if (isset($imgix_options['add_dpi2_srcset']) && $imgix_options['add_dpi2_srcset']) {
 	function buffer_start() { ob_start("add_retina"); }

--- a/includes/options_page.php
+++ b/includes/options_page.php
@@ -1,49 +1,51 @@
 <?php
+/**
+ * @package imgix
+ */
 function imgix_options_page() {
+
 	global $imgix_options;
 
-	ob_start();
 ?>
 	<div class="wrap">
-		<p><img src="https://assets.imgix.net/imgix-logo-web-2014.pdf?page=2&fm=png&w=200&h=200"></p>
+
+		<h1><img src="https://assets.imgix.net/imgix-logo-web-2014.pdf?page=2&fm=png&w=200&h=200" alt="imgix Logo"></h1>
+
 		<p><strong>Need help getting started?</strong> It's easy! Check out our <a href="https://github.com/wladston/imgix-wordpress#getting-started" target="_blank">instructions.</a></p>
+
 		<form method="post" action="options.php">
-			<?php settings_fields('imgix_settings_group'); ?>
+			<?php settings_fields( 'imgix_settings_group' ); ?>
 
-			<table>
+			<table class="form-table">
 
-				<tr>
-					<td><label class="description" for="imgix_settings[cdn_link]"><?php _e('imgix Source', 'imgix_domain'); ?></td>
-					  <td><input id="imgix_settings[cdn_link]" type="url" name="imgix_settings[cdn_link]" placeholder="http://yourcompany.imgix.net" value="<?php echo isset($imgix_options['cdn_link']) ? $imgix_options['cdn_link'] : ''; ?>" style="width:270px" /><small></td>
-					  <td></td>
-				</tr>
+				<tbody>
 
-				<tr>
-					<td><label class="description" for="imgix_settings[auto_format]"><?php _e('<a href="http://blog.imgix.com/post/90838796454/webp-jpeg-xr-progressive-jpg-support-w-auto" target="_blank">Auto Format</a> Images', 'auto_format'); ?></label></td>
-					<td><input id="imgix_settings[auto_format]" type="checkbox" name="imgix_settings[auto_format]" value="1" <?php echo isset($imgix_options['auto_format']) && $imgix_options['auto_format'] === "1" ? 'checked="checked"': ''; ?> /></td>
-					<td></td>
-				</tr>
+					<tr>
+						<th><label class="description" for="imgix_settings[cdn_link]"><?php _e( 'imgix Source', 'imgix_domain' ); ?></th>
+						<td><input id="imgix_settings[cdn_link]" type="url" name="imgix_settings[cdn_link]" placeholder="https://yourcompany.imgix.net" value="<?php echo isset( $imgix_options['cdn_link'] ) ? $imgix_options['cdn_link'] : ''; ?>" class="regular-text code" /></td>
+					</tr>
 
-				<tr>
-					<td><label class="description" for="imgix_settings[auto_enhance]"><?php _e('<a href="http://blog.imgix.com/post/85095931364/autoenhance" target="_blank">Auto Enhance</a> Images', 'auto_enhance'); ?></label></td>
-					<td><input id="imgix_settings[auto_enhance]" type="checkbox" name="imgix_settings[auto_enhance]" value="1" <?php echo isset($imgix_options['auto_enhance']) && $imgix_options['auto_enhance'] === "1" ? 'checked="checked"': ''; ?> /></td>
-					<td></td>
-				</tr>
+					<tr>
+						<th><label class="description" for="imgix_settings[auto_format]"><?php _e( '<a href="http://blog.imgix.com/post/90838796454/webp-jpeg-xr-progressive-jpg-support-w-auto" target="_blank">Auto Format</a> Images', 'auto_format' ); ?></label></th>
+						<td><input id="imgix_settings[auto_format]" type="checkbox" name="imgix_settings[auto_format]" value="1" <?php echo isset( $imgix_options['auto_format'] ) && $imgix_options['auto_format'] === "1" ? 'checked="checked"' : ''; ?> /></td>
+					</tr>
 
-				<tr>
-					<td><label class="description" for="imgix_settings[add_dpi2_srcset]"><?php _e('Automatically add retina images using srcset', 'add_dpi2_srcset'); ?></label></td>
-					<td><input id="imgix_settings[add_dpi2_srcset]" type="checkbox" name="imgix_settings[add_dpi2_srcset]" value="1" <?php echo isset($imgix_options['add_dpi2_srcset']) && $imgix_options['add_dpi2_srcset'] === "1" ? 'checked="checked"': ''; ?> /></td>
-					<td></td>
-				</tr>
+					<tr>
+						<th><label class="description" for="imgix_settings[auto_enhance]"><?php _e( '<a href="http://blog.imgix.com/post/85095931364/autoenhance" target="_blank">Auto Enhance</a> Images', 'auto_enhance' ); ?></label></th>
+						<td><input id="imgix_settings[auto_enhance]" type="checkbox" name="imgix_settings[auto_enhance]" value="1" <?php echo isset( $imgix_options['auto_enhance'] ) && $imgix_options['auto_enhance'] === "1" ? 'checked="checked"' : ''; ?> /></td>
+					</tr>
 
-				<tr>
-					<td colspan="2">
-					<p class="submit">
-						<input type="submit" class="button-primary" value="<?php _e('Save Options', 'imgix_domain'); ?>" />
-					</p>
-					</td>
-				</tr>
+					<tr>
+						<th><label class="description" for="imgix_settings[add_dpi2_srcset]"><?php _e( 'Automatically add retina images using srcset', 'add_dpi2_srcset' ); ?></label></th>
+						<td><input id="imgix_settings[add_dpi2_srcset]" type="checkbox" name="imgix_settings[add_dpi2_srcset]" value="1" <?php echo isset( $imgix_options['add_dpi2_srcset'] ) && $imgix_options['add_dpi2_srcset'] === "1" ? 'checked="checked"' : ''; ?> /></td>
+					</tr>
+
+				</tbody>
 			</table>
+
+			<p class="submit">
+				<input type="submit" class="button-primary" value="<?php _e( 'Save Options', 'imgix_domain' ); ?>" />
+			</p>
 		</form>
 
 		<p class="description">
@@ -51,17 +53,16 @@ function imgix_options_page() {
 		</p>
 	</div>
 <?php
-	echo ob_get_clean();
 }
 
 function imgix_add_options_link() {
-	add_options_page('imgix', 'imgix', 'manage_options', 'imgix-options', 'imgix_options_page');
+	add_options_page( 'imgix', 'imgix', 'manage_options', 'imgix-options', 'imgix_options_page' );
 }
-add_action('admin_menu', 'imgix_add_options_link');
+add_action( 'admin_menu', 'imgix_add_options_link' );
 
 function imgix_register_settings() {
 	// creates our settings in the options table
-	register_setting('imgix_settings_group', 'imgix_settings');
+	register_setting( 'imgix_settings_group', 'imgix_settings' );
 }
 
-add_action('admin_init', 'imgix_register_settings');
+add_action( 'admin_init', 'imgix_register_settings' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imgix-wordpress",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "official imgix WordPress plugin",
   "main": "",
   "scripts": {


### PR DESCRIPTION
Hey @wladston,

Possibly should have split this out better, but the main change is switching from using the `no_image_downsize` filter to instead use str_replace on src/srcset attributes.

Then a bundle of styling alterations to bring things in line with the [WordPress' PHP styleguide](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#use-elseif-not-else-if) 
