### PR TITLE
images-via-imgix external CDN feature

### DIFF
--- a/includes/class-images-via-imgix.php
+++ b/includes/class-images-via-imgix.php
@@ -106,7 +106,7 @@ class Images_Via_Imgix {
 						unset( $parsed_url[ $url_part ] );
 					}
 				}
-				if ( ! empty($this->options['external_cdn_link'] ) ) {
+				if ( ! empty( $this->options['external_cdn_link'] ) ) {
                     //Modify the CDN URL, we won't need any parts after the host.
                     $parsed_cdn_url = parse_url( $this->options['external_cdn_link'] );
                     $parsed_url['path'] = str_replace( $parsed_cdn_url['path'], "", $parsed_url['path'] );

--- a/includes/class-images-via-imgix.php
+++ b/includes/class-images-via-imgix.php
@@ -97,7 +97,11 @@ class Images_Via_Imgix {
 			$parsed_url = parse_url( $url );
 
 			//Check if image is hosted on current site url -OR- the CDN url specified. Using strpos because we're comparing the host to a full CDN url.
-			if ( isset( $parsed_url['host'], $parsed_url['path'] ) && ($parsed_url['host'] === parse_url( home_url( '/' ), PHP_URL_HOST ) || strpos( ( $this->options['external_cdn_link'] ? $this->options['external_cdn_link'] : "" ), $parsed_url['host'] ) !== false) && preg_match( '/\.(jpg|jpeg|gif|png)$/i', $parsed_url['path'] ) ) {
+            if (
+                isset( $parsed_url['host'], $parsed_url['path'] )
+                && ($parsed_url['host'] === parse_url( home_url( '/' ), PHP_URL_HOST ) || ( isset($this->options['external_cdn_link']) && ! empty($this->options['external_cdn_link']) && strpos( $this->options['external_cdn_link'], $parsed_url['host']) !== false ) )
+                && preg_match( '/\.(jpg|jpeg|gif|png)$/i', $parsed_url['path'] )
+            ) {
 				$cdn = parse_url( $this->options['cdn_link'] );
 				foreach ( [ 'scheme', 'host', 'port' ] as $url_part ) {
 					if ( isset( $cdn[ $url_part ] ) ) {

--- a/includes/class-images-via-imgix.php
+++ b/includes/class-images-via-imgix.php
@@ -29,7 +29,7 @@ class Images_Via_Imgix {
 	public function __construct() {
 		$this->options = get_option( 'imgix_settings', [] );
 
-		//Change filter load order to ensure it loads after other CDN url transformations i.e. Amazon S3 which loads at position 99.
+		// Change filter load order to ensure it loads after other CDN url transformations i.e. Amazon S3 which loads at position 99.
 		add_filter( 'wp_get_attachment_url', [ $this, 'replace_image_url' ], 100 );
 		add_filter( 'imgix/add-image-url', [ $this, 'replace_image_url' ] );
 
@@ -97,7 +97,7 @@ class Images_Via_Imgix {
 			$parsed_url = parse_url( $url );
 
 			//Check if image is hosted on current site url -OR- the CDN url specified. Using strpos because we're comparing the host to a full CDN url.
-			if ( isset( $parsed_url['host'], $parsed_url['path'] ) && ($parsed_url['host'] === parse_url( home_url( '/' ), PHP_URL_HOST ) || strpos(($this->options['external_cdn_link'] ? $this->options['external_cdn_link'] : ""), $parsed_url['host']) !== false) && preg_match( '/\.(jpg|jpeg|gif|png)$/i', $parsed_url['path'] ) ) {
+			if ( isset( $parsed_url['host'], $parsed_url['path'] ) && ($parsed_url['host'] === parse_url( home_url( '/' ), PHP_URL_HOST ) || strpos( ( $this->options['external_cdn_link'] ? $this->options['external_cdn_link'] : "" ), $parsed_url['host'] ) !== false) && preg_match( '/\.(jpg|jpeg|gif|png)$/i', $parsed_url['path'] ) ) {
 				$cdn = parse_url( $this->options['cdn_link'] );
 				foreach ( [ 'scheme', 'host', 'port' ] as $url_part ) {
 					if ( isset( $cdn[ $url_part ] ) ) {
@@ -106,9 +106,11 @@ class Images_Via_Imgix {
 						unset( $parsed_url[ $url_part ] );
 					}
 				}
-				//Modify the CDN URL, we won't need any parts after the host.
-                $parsed_cdn_url = parse_url($this->options['external_cdn_link']);
-                $parsed_url['path'] = str_replace($parsed_cdn_url['path'], "", $parsed_url['path']);
+				if ( ! empty($this->options['external_cdn_link'] ) ) {
+                    //Modify the CDN URL, we won't need any parts after the host.
+                    $parsed_cdn_url = parse_url( $this->options['external_cdn_link'] );
+                    $parsed_url['path'] = str_replace( $parsed_cdn_url['path'], "", $parsed_url['path'] );
+                }
 
 				$url = http_build_url( $parsed_url );
 
@@ -198,7 +200,7 @@ class Images_Via_Imgix {
 	 * @return string
 	 */
 	public function replace_images_in_content( $content ) {
-	    //Added null to apply filters wp_get_attachment_url to improve compatibility with https://en-gb.wordpress.org/plugins/amazon-s3-and-cloudfront/ - does not break wordpress if the plugin isn't present.
+	    // Added null to apply filters wp_get_attachment_url to improve compatibility with https://en-gb.wordpress.org/plugins/amazon-s3-and-cloudfront/ - does not break wordpress if the plugin isn't present.
 		if ( ! empty ( $this->options['cdn_link'] ) ) {
 			if ( preg_match_all( '/<img\s[^>]*src=([\"\']??)([^\" >]*?)\1[^>]*>/iU', $content, $matches ) ) {
 				foreach ( $matches[2] as $image_src ) {

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -63,6 +63,14 @@ class Imgix_Options_page {
 								<input id="imgix_settings[cdn_link]" type="url" name="imgix_settings[cdn_link]" placeholder="https://yourcompany.imgix.net" value="<?php echo $this->get_option( 'cdn_link' ); ?>" class="regular-text code"/>
 							</td>
 						</tr>
+                        <tr>
+                            <th>
+                                <label class="description" for="imgix_settings[external_cdn_link]"><?php esc_html_e( 'CDN URL', 'imgix' ); ?>
+                            </th>
+                            <td>
+                                <input id="imgix_settings[external_cdn_link]" type="url" name="imgix_settings[external_cdn_link]" placeholder="http://s3-eu-west-2.amazonaws.com/your-bucket" value="<?php echo $this->get_option( 'external_cdn_link' ); ?>" class="regular-text code"/>
+                            </td>
+                        </tr>
 						<tr>
 							<th>
 								<label class="description" for="imgix_settings[auto_format]"><?php esc_html_e( 'Auto Format Images', 'imgix' ); ?></label>


### PR DESCRIPTION
Hi There,

I noticed an open issue which matches a use case I'm trying to achieve with your images-via-imgix plugin. The ability to have images that are hosted on a CDN or another site show via imgix.

The specific user case for me is having images uploaded to my WordPress site to be automatically uploaded to S3 as a CDN, then have imgix point at the S3 URL to serve images. To achieve this I've utilised your plugin and https://en-gb.wordpress.org/plugins/amazon-s3-and-cloudfront/ 

This pull request contains the changes I've had to make to your imgix plugin in order for this to work. All the changes I've made have had backwards compatibility in mind, they should not break the plugin for existing users, and just add this external CDN functionality.

I've been able to test this on my own development site with images hosted on S3 and everything is looking good. I'm going to continue developing this site further and will resolve any issues I encounter.

Please let me know your thoughts, I welcome your feedback on this.

Many Thanks,
Matt