### PR TITLE
Fix image_downsize when generating pdf thumbnails

### DIFF
--- a/includes/class-images-via-imgix.php
+++ b/includes/class-images-via-imgix.php
@@ -158,6 +158,11 @@ class Images_Via_Imgix {
 			if ( ! isset( $width ) || ! isset( $height ) ) {
 				// any other type: use the real image
 				$meta   = wp_get_attachment_metadata( $attachment_id );
+				
+				// Image sizes is missing for pdf thumbnails
+				$meta['width']  = isset( $meta['width'] ) ? $meta['width'] : 0;
+				$meta['height'] = isset( $meta['height'] ) ? $meta['height'] : 0;
+				
 				$width  = isset( $width ) ? $width : $meta['width'];
 				$height = isset( $height ) ? $height : $meta['height'];
 			}


### PR DESCRIPTION
image_downsize also runs on pdf thumbnails that is missing sizes some times.