### PR TITLE
Fixed notice about ob_end_flush()

### DIFF
--- a/includes/class-images-via-imgix.php
+++ b/includes/class-images-via-imgix.php
@@ -41,7 +41,7 @@ class Images_Via_Imgix {
 		add_action( 'wp_head', [ $this, 'prefetch_cdn' ], 1 );
 
 		add_action( 'after_setup_theme', [ $this, 'buffer_start_for_retina' ] );
-		add_action( 'shutdown', [ $this, 'buffer_end_for_retina' ] );
+		add_action( 'shutdown', [ $this, 'buffer_end_for_retina' ], 0 );
 	}
 
 	/**
@@ -251,8 +251,7 @@ class Images_Via_Imgix {
 	 */
 	public function buffer_start_for_retina() {
 		if ( ! empty ( $this->options['add_dpi2_srcset'] ) ) {
-			$this->buffer_started = true;
-			ob_start( [ $this, 'add_retina' ] );
+			$this->buffer_started = ob_start( [ $this, 'add_retina' ] );
 		}
 	}
 
@@ -260,7 +259,7 @@ class Images_Via_Imgix {
 	 * Stop output buffer if it was enabled by the plugin
 	 */
 	public function buffer_end_for_retina() {
-		if ( $this->buffer_started === true ) {
+		if ( $this->buffer_started && ob_get_level() ) {
 			ob_end_flush();
 		}
 	}


### PR DESCRIPTION
This fixes a PHP notice when `WP_DEBUG` is on.

- Changed `buffer_end_for_retina()` priority so it runs before [`wp_ob_end_flush_all()`](https://github.com/WordPress/WordPress/blob/b8fc8cb59cfd4581175be8c7ea3a839e1968f0df/wp-includes/default-filters.php#L313).
- Set `buffer_started` to the return value of `ob_start()` so you know if the buffer actually started instead of assuming it did.
- Use `ob_get_level()` to see if buffering is still active. Other plugins may have flushed the buffers.

![image](https://user-images.githubusercontent.com/1823514/32668101-44ce633c-c602-11e7-852e-1af6c19f8387.png)
