### PR TITLE
Add conditional to replace background image urls

### DIFF
--- a/includes/class-images-via-imgix.php
+++ b/includes/class-images-via-imgix.php
@@ -258,6 +258,12 @@ class Images_Via_Imgix {
 					$content = str_replace( $link[2], apply_filters( 'wp_get_attachment_url', $link[2], null ), $content );
 				}
 			}
+
+      if ( preg_match_all('/url\(([\s])?([\"|\'])?(.*?)([\"|\'])?([\s])?\)/i', $content, $matches ) ) {
+        foreach ( $matches[3] as $image_src ) {
+          $content = str_replace( $image_src, apply_filters( 'wp_get_attachment_url', $image_src, null ), $content );
+        }
+      }
 		}
 		return $content;
 	}


### PR DESCRIPTION
In the Gutenberg editor, the Cover Image block displays images using inline styles:

```
<div class="wp-block-cover-image has-background-dim" style="background-image:url(https://s3-ap-southeast-2.amazonaws.com/bucket/image.jpg)">
  <p class="wp-block-cover-image-text"></p>
</div>
```

This pull request adds a new condition to match on background images. Open to improvements.
